### PR TITLE
New instructions on intro screen + disclaimer before signing

### DIFF
--- a/docassemble/ssareportchangesletter/data/questions/ssa_report_change.yml
+++ b/docassemble/ssareportchangesletter/data/questions/ssa_report_change.yml
@@ -8,21 +8,35 @@ metadata:
     If you get SSI or SSDI, you need to tell Social Security about changes in your life. 
     This tool helps you write a letter to Social Security to report changes, including:
 
-    * Moving
-    * Starting to live by yourself or with someone else
-    * Being in jail
-    * Being in the hospital
+    * Starting or Stopping a job
+    * Income change
+    * Moving or Change in mail address
+    * Change in number of household members
+    * Receiving a warrant for your arrest
+    * Being Convicted of a criminal offense
+    * Being in jail or prison
+    * Being in the hospital, rehab, or halfway house
     * Being in a nursing home
     * Being outside the United States for more than 30 days
+    * Change in immigration status or citizenship status
+    * Name Change
+    * Phone Number Change
     * Getting help to pay for rent or food
+    * Getting money from a pension, workers compensation, or other benefit
     * Getting money from a lawsuit or lottery
     * Getting married or divorced
+    * Becoming a birth, adoptive, or step parent
+
+    Report these changes promptly and no later than the tenth day of the month after they happen to       get an accurate payment of benefits.
   can_I_use_this_form: |
     You can use this form if you are on SSI or SSDI and need to report changes to Social Security.
   before_you_start: |
-    Before you start, you need to know if you are on SSI (Supplemental Security Income), SSDI (Social Security Disability), or both. If you are working and getting paid, you also need the name and address of the place you work, the number of hours you work, and how much you are paid. Your pay stubs should have all this information on them, so having them with you from the start will be helpful. If you are answering questions for someone else, you need their full name, address, and Social Security number.
+    Before you start, you need to know: 
+    1. Are you on SSI (Supplemental Security Income), SSDI (Social Security Disability), or both?
+    2. If you are working and getting paid, you need the name and address of the place you work, the      number of hours you work, and how much you are paid. Your pay stubs should have all this              information on them, so having them with you from the start will be helpful. 
+    3. If you are answering questions for someone else, you need their full name, address, and Social     Security number.
 
-    Make sure you have specific information, like dates and addresses, before you start. This will help you complete the form more quickly.
+    Make sure you have specific information, like dates and addresses, before you start. This will        help you complete the form more quickly.
   maturity: production
   estimated_completion_minutes: 15
   estimated_completion_delta: 15
@@ -199,27 +213,33 @@ field: intro_screen
 question: |
   We're here to help.
 subquestion: |
-  This is a tool for people on SSI or SSDI disability benefits. It will help you write
+  This is a tool for people on SSI or SSDI benefits. It will help you write
   a letter to the Social Security Administration (Social Security) to tell them about 
   [important changes](https://blog.ssa.gov/reporting-changes-is-your-responsibility/) 
-  in your life they need to know about.
+  in your life they need to know about. You must report any changes by the tenth day of the month       after they happen to get an accurate payment of benefits.
 
-  Before you start, you need to know if you are on
+  You also can report changes to Social Security by calling +1 800-772-1213 or calling TTY +1 800-325-0778 Monday to Friday in English and other languages. 
+
+  Before you start, you need to know if you are on:
   
-  * SSI (Supplemental Security Income), 
+  * SSI (Supplemental Security Income) or
   * SSDI (Social Security Disability) or
-  * SSI and SSDI.
+  * Both SSI and SSDI.
   
   If you are working and getting paid, you also need:
-  the name and address of the place you work, 
-  the number of hours you work, and
-  how much you are paid.
-  Your pay stubs should have all this information on them, so having them with you 
+  
+  1. Name and Address of the place you work, 
+  2. Number of hours you work
+  3. How much you are paid
+  
+  Your pay stubs should have this information on them, so having them with you 
   from the start will be helpful.
+  
   If you are answering questions  for someone else, you need their:
-  full name, 
-  address, and 
-  Social Security number.
+  
+  1. Full Name 
+  2. Address 
+  3. Social Security number
 fields: 
   - To continue you must accept the [terms of use](https://vlpnet.org/tos-for-guided-interviews/): intro_screen
     datatype: checkboxes
@@ -632,11 +652,19 @@ subquestion: |
   a final copy.
   
   ${ pdf_concatenate(final_form['preview'], filename="preview_do_not_use.pdf") }
+
+  Remember to come back to this window to continue and sign your form.
+
+  When you sign this form you are saying the following:
+
+  “I declare under penalty of perjury that I have examined all the information on this form, and on     any accompanying statements or forms, and it is true and correct to the best of my knowledge. I       understand that anyone who knowingly gives a false statement about a material fact in this            information, or causes someone else to do so, commits a crime and may be subject to a fine or         imprisonment.”
 continue button field: preview_your_form  
 ---
 id: signature
 question: |
   Sign your letter
+subquestion: |
+  
 signature: client.signature
 under: |
   ${client}


### PR DESCRIPTION
I added a quick disclaimer to the user before they sign letting them know that they are attesting to the contents of the letter under penalties of perjury. I also updated the intro screen instructions to include the phone hotline to report changes, and I reformatted/edited the text of the instructions so that it is easier to read.

Fix #40 