### PR TITLE
Fix issue with YAML parsing

### DIFF
--- a/docassemble/ssareportchangesletter/data/questions/ssa_report_change.yml
+++ b/docassemble/ssareportchangesletter/data/questions/ssa_report_change.yml
@@ -37,7 +37,6 @@ metadata:
 
 
     Report these changes promptly and no later than the tenth day of the month after they happen to       get an accurate payment of benefits.
-main
   can_I_use_this_form: |
     You can use this form if you are on SSI or SSDI and need to report changes to Social Security.
   before_you_start: |


### PR DESCRIPTION
That issue had been there for a long time; why did `dabuild` not catch it, and why is it only just now failing in prod? 

Error on prod: 
```
Error reading YAML file docassemble.ssareportchangesletter:data/questions/ssa_report_change.yml in the block on line 11
...
Error was:

while scanning a simple key
  in docassemble.ssareportchangesletter:data/questions/ssa_report_change.yml, line 40, column 1
could not find expected ':'
```